### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,3 +15,9 @@ Terraform-managed repository that builds shared Azure Monitor primitives. Two Te
 ## Stack-specific conventions
 - Key Vault uses RBAC + purge protection; `alert-email` and `alert-phone` secrets require manual rotation (see `docs/manual-steps.md`).
 - Outputs expose Log Analytics workspace and action group identifiers for downstream consumers.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,4 +32,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: npm ci && npm run build

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo is wired to the shared `frasermolyneux-copilot` MCP server (see `.github/copilot/mcp_config.json` and the `Build MCP server` step in `.github/workflows/copilot-setup-steps.yml`). The server is pinned to tag `v0.1.0` of `frasermolyneux/.github-copilot`. For full setup, client configuration, and the tool contract, see `mcp-server/README.md` in [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot/blob/main/mcp-server/README.md).


### PR DESCRIPTION
Wires this repo into the shared `frasermolyneux-copilot` MCP server so Copilot CLI / coding-agent sessions can resolve org conventions (instructions, prompts, agents) directly from `frasermolyneux/.github-copilot` at runtime instead of relying solely on file loads. Matches the template already merged into `portal-core` and is pinned to tag `v0.1.0`.

## Changes

- **`.github/workflows/copilot-setup-steps.yml`** — pin the existing `frasermolyneux/.github-copilot` checkout to `refs/tags/v0.1.0`, add `actions/setup-node@v6` (Node 20.x), and add a `Build MCP server` step running `npm ci && npm run build` in `.github-copilot/mcp-server` so the server binary is ready before the agent starts.
- **`.github/copilot/mcp_config.json`** (new) — declares the `frasermolyneux-copilot` local stdio MCP server pointing at `.github-copilot/mcp-server/dist/index.js` with `GH_COPILOT_CONTENT_ROOT=.github-copilot` and `tools: ["*"]`.
- **`.github/copilot-instructions.md`** — appends the canonical `## Org conventions via MCP (when available)` snippet that tells MCP-capable agents to prefer catalog tools when a server is wired in. Byte-identical to the source-of-truth (sha256 `DDAC8AA449794730F687EA61759C392D45C6C4E6C7A85C608EF365E15E748F6B`, 1096 bytes).
- **`README.md`** — adds a brief `## Local dev: MCP wire-up` section pointing at `mcp-server/README.md` in `frasermolyneux/.github-copilot` rather than duplicating the docs here.

## Notes for reviewers

- `AGENTS.md` is **not** created here — the file does not exist in this repo and is owned by the `update-project-metadata` agent. A follow-up session should scaffold it and embed the same MCP snippet byte-identically. Until then, this repo is half-wired vs the `portal-core` template (acceptable; tracked).
- The snippet is intentionally conditional ("when available"), so it reads as a no-op for clients without the MCP server configured and activates cleanly once `.github/copilot/mcp_config.json` is picked up.